### PR TITLE
Upload to GitHub Packages natively

### DIFF
--- a/ShareFileJavaSDK/build.gradle
+++ b/ShareFileJavaSDK/build.gradle
@@ -2,6 +2,7 @@ apply plugin: 'java'
 apply plugin: 'eclipse'
 apply plugin: 'java-library-distribution'
 apply plugin: 'maven'
+apply plugin: 'maven-publish'
 apply plugin: 'signing'
 
 String shareFileJarName = 'sharefile-api'
@@ -108,6 +109,25 @@ uploadArchives {
     repositories {
         mavenDeployer {
            repository(url: mavenLocal().getUrl())
+        }
+    }
+}
+
+publishing {
+    repositories {
+        maven {
+            name = 'everlawRepository'
+            url = uri('https://maven.pkg.github.com/Everlaw/servers')
+            credentials {
+                username = project.findProperty('everlawRepositoryUsername')
+                password = project.findProperty('everlawRepositoryPassword')
+            }
+        }
+    }
+    publications {
+        gpr(MavenPublication) {
+            artifactId = 'sharefile-api'
+            from(components.java)
         }
     }
 }

--- a/ShareFileJavaSDK/build.gradle
+++ b/ShareFileJavaSDK/build.gradle
@@ -6,7 +6,7 @@ apply plugin: 'maven-publish'
 apply plugin: 'signing'
 
 String shareFileJarName = 'sharefile-api'
-String shareFileJarVersion = '3.1.9'
+String shareFileJarVersion = '3.1.9-everlaw1'
 String shareFilePomFileName = "$buildDir/libs/"+shareFileJarName+"-"+shareFileJarVersion+".pom"
 
 group = "com.everlaw"


### PR DESCRIPTION
This PR makes it possible to run
```sh
$ cd ShareFileJavaSDK/
$ JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64 ./gradlew deploy
```
in order to publish JARs to https://github.com/orgs/Everlaw/packages.